### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/postgis.yml
+++ b/.github/workflows/postgis.yml
@@ -20,7 +20,7 @@ jobs:
           fi
 
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@2.12
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           ALEMBIC_VERSION: c77774920e5b
         with:

--- a/.github/workflows/qgis-server.yml
+++ b/.github/workflows/qgis-server.yml
@@ -18,7 +18,7 @@ jobs:
           echo ::set-output name=tags::$VERSION_TRIPLE,$VERSION_MINOR
 
       - name: Build and publish docker image for QGIS Server 3 LTR
-        uses: elgohr/Publish-Docker-Github-Action@2.12
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           URL_PREFIX: /ows
         with:
@@ -38,7 +38,7 @@ jobs:
           echo ::set-output name=tags::$VERSION_TRIPLE,$VERSION_MINOR,latest
 
       - name: Build and publish docker image for QGIS Server 3
-        uses: elgohr/Publish-Docker-Github-Action@2.12
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           URL_PREFIX: /ows
         with:
@@ -57,7 +57,7 @@ jobs:
           echo ::set-output name=tags::$VERSION_TRIPLE,$VERSION_MINOR
 
       - name: Build and publish docker image for QGIS Server 2
-        uses: elgohr/Publish-Docker-Github-Action@2.12
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           URL_PREFIX: /ows
         with:

--- a/.github/workflows/uwsgi-base.yml
+++ b/.github/workflows/uwsgi-base.yml
@@ -22,7 +22,7 @@ jobs:
           fi
 
       - name: Build and publish Alpine docker image
-        uses: elgohr/Publish-Docker-Github-Action@2.12
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: sourcepole/qwc-uwsgi-base
           username: ${{ secrets.DOCKER_HUB_USER }}
@@ -31,7 +31,7 @@ jobs:
           workdir: uwsgi-base/alpine
 
       - name: Build and publish Ubuntu docker image
-        uses: elgohr/Publish-Docker-Github-Action@2.12
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: sourcepole/qwc-uwsgi-base
           username: ${{ secrets.DOCKER_HUB_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore